### PR TITLE
fix: loading target to all pages after 3 seconds

### DIFF
--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,5 +1,5 @@
 import "@plasmohq/messaging/background"
 
-import {startHub} from "@plasmohq/messaging/pub-sub"
+import { startHub } from "@plasmohq/messaging/pub-sub"
 
 startHub()

--- a/extension/src/background/messages/oauth.ts
+++ b/extension/src/background/messages/oauth.ts
@@ -1,40 +1,41 @@
-import type {PlasmoMessaging} from "@plasmohq/messaging"
-import type {TwitchUser} from "~types/types";
+import type { PlasmoMessaging } from "@plasmohq/messaging"
 
-const CLIENT_ID = 'vfir3y164p9aiv3v6nkbsjg0wdx4za';
-const REDIRECT_URI = browser.identity.getRedirectURL();
+import type { TwitchUser } from "~types/types"
+
+const CLIENT_ID = "vfir3y164p9aiv3v6nkbsjg0wdx4za"
+const REDIRECT_URI = browser.identity.getRedirectURL()
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
-    console.log("Redirect URI")
-    console.log(REDIRECT_URI)
-    const AUTH_URL = `https://id.twitch.tv/oauth2/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=token&scope=user:read:email`;
+  console.log("Redirect URI")
+  console.log(REDIRECT_URI)
+  const AUTH_URL = `https://id.twitch.tv/oauth2/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=token&scope=user:read:email`
 
-    const redirectURL = await browser.identity.launchWebAuthFlow({
-        interactive: true,
-        url: AUTH_URL
-    });
+  const redirectURL = await browser.identity.launchWebAuthFlow({
+    interactive: true,
+    url: AUTH_URL
+  })
 
-    let urlParams = new URLSearchParams(redirectURL);
-    let accessToken = urlParams.entries().next().value[1];
+  let urlParams = new URLSearchParams(redirectURL)
+  let accessToken = urlParams.entries().next().value[1]
 
-    await browser.storage.local.set({accessToken});
+  await browser.storage.local.set({ accessToken })
 
-    let authenticatedUser = await fetch('https://api.twitch.tv/helix/users', {
-        headers: {
-            'Client-ID': CLIENT_ID,
-            Authorization: `Bearer ${accessToken}`
-        }
-    });
-    let user = await authenticatedUser.json();
-    user = user.data[0] as TwitchUser;
-    user.id = parseInt(user.id);
+  let authenticatedUser = await fetch("https://api.twitch.tv/helix/users", {
+    headers: {
+      "Client-ID": CLIENT_ID,
+      Authorization: `Bearer ${accessToken}`
+    }
+  })
+  let user = await authenticatedUser.json()
+  user = user.data[0] as TwitchUser
+  user.id = parseInt(user.id)
 
-    await browser.storage.local.set({user});
+  await browser.storage.local.set({ user })
 
-    res.send({
-        auth: true,
-        user: user
-    })
+  res.send({
+    auth: true,
+    user: user
+  })
 }
 
 export default handler

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,3 +1,24 @@
+{
+}
+
+import type {PlasmoCSConfig} from "plasmo"
+import {sendToBackground} from "@plasmohq/messaging"
+
+export const config: PlasmoCSConfig = {
+    matches: [
+        "https://dashboard.twitch.tv/u/*/stream-manager",
+        "https://www.twitch.tv/embed/*/chat*",
+        "https://www.twitch.tv/*"
+    ],
+    exclude_matches: [
+        "*://*.twitch.tv/*.html",
+        "*://*.twitch.tv/*.html?*",
+        "*://*.twitch.tv/*.htm",
+        "*://*.twitch.tv/*.htm?*"
+    ],
+    all_frames: true
+}
+
 const buildBadge = (badge) => {
     // Create a div element
     const badgeContainer = document.createElement('div');
@@ -71,7 +92,6 @@ let mutation = new MutationObserver((mutations) => {
                 return
             }
 
-
             let res = await response.json();
             console.log(res)
 
@@ -91,9 +111,20 @@ let mutation = new MutationObserver((mutations) => {
     messageEl = null;
 });
 
-const chat = document.querySelector('.chat-scrollable-area__message-container');
-if (chat) {
+console.log('puta que pariu funciona')
+
+const appLoader = () => {
+    console.log('carregou')
+    let chat = document.querySelector('.chat-list--default');
+    if (!chat) {
+        return setTimeout(appLoader, 3000);
+    }
+
     console.log("observer on");
     const mutationConfig = {childList: true, subtree: true, characterData: true};
     mutation.observe(chat, mutationConfig);
 }
+
+setTimeout(appLoader, 3000)
+
+

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,128 +1,128 @@
-{
-}
-
-import type {PlasmoCSConfig} from "plasmo"
-import {sendToBackground} from "@plasmohq/messaging"
+import type { PlasmoCSConfig } from "plasmo"
 
 export const config: PlasmoCSConfig = {
-    matches: [
-        "https://dashboard.twitch.tv/u/*/stream-manager",
-        "https://www.twitch.tv/embed/*/chat*",
-        "https://www.twitch.tv/*"
-    ],
-    exclude_matches: [
-        "*://*.twitch.tv/*.html",
-        "*://*.twitch.tv/*.html?*",
-        "*://*.twitch.tv/*.htm",
-        "*://*.twitch.tv/*.htm?*"
-    ],
-    all_frames: true
+  matches: [
+    "https://dashboard.twitch.tv/u/*/stream-manager",
+    "https://www.twitch.tv/embed/*/chat*",
+    "https://www.twitch.tv/*"
+  ],
+  exclude_matches: [
+    "*://*.twitch.tv/*.html",
+    "*://*.twitch.tv/*.html?*",
+    "*://*.twitch.tv/*.htm",
+    "*://*.twitch.tv/*.htm?*"
+  ],
+  all_frames: true
 }
 
-const buildBadge = (badge) => {
-    // Create a div element
-    const badgeContainer = document.createElement('div');
-    badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA";
+const buildBadge = (_badge) => {
+  // Create a div element
+  const badgeContainer = document.createElement("div")
+  badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA"
 
-    // Create an img element
-    const img = document.createElement('img');
-    img.alt = "Just a thing";
-    img.width = 18;
-    img.setAttribute('aria-label', 'Just a thing');
-    img.className = "chat-badge";
-    img.src = "https://twitch-extension.danielheart.dev/static/icons/mod.png";
-    img.srcset = "https://twitch-extension.danielheart.dev/static/icons/mod.png 1x,https://twitch-extension.danielheart.dev/static/icons/mod.png 2x,https://twitch-extension.danielheart.dev/static/icons/mod.png 4x";
+  // Create an img element
+  const img = document.createElement("img")
+  img.alt = "Just a thing"
+  img.width = 18
+  img.setAttribute("aria-label", "Just a thing")
+  img.className = "chat-badge"
+  img.src = "https://twitch-extension.danielheart.dev/static/icons/mod.png"
+  img.srcset =
+    "https://twitch-extension.danielheart.dev/static/icons/mod.png 1x,https://twitch-extension.danielheart.dev/static/icons/mod.png 2x,https://twitch-extension.danielheart.dev/static/icons/mod.png 4x"
 
-    // Append the img to the div
-    badgeContainer.appendChild(img);
+  // Append the img to the div
+  badgeContainer.appendChild(img)
 
-    return badgeContainer;
+  return badgeContainer
 }
 
 let mutation = new MutationObserver((mutations) => {
+  if (mutations[0].previousSibling.localName === "span") {
+    return
+  }
 
-    if (mutations[0].previousSibling.localName === 'span') {
+  console.log(mutations)
+  let messageEl = null
+  for (let mutation of mutations) {
+    let isChildList = mutation.type === "childList"
+
+    if (!isChildList) {
+      console.log("Not a childList mutation")
+      continue
+    }
+
+    const addedNode = mutation.addedNodes[0]
+    if (!(addedNode instanceof HTMLElement)) {
+      continue
+    }
+
+    const isMessageEl = addedNode.classList.contains("chat-line__message")
+    if (!isMessageEl) {
+      continue
+    }
+
+    messageEl = addedNode
+    break
+  }
+
+  if (messageEl === null) {
+    return
+  }
+
+  let usernameEl = messageEl.querySelector(".chat-line__username")
+  let badgesEl = messageEl.querySelector(".chat-line__username-container")
+    .childNodes[0]
+
+  console.log(badgesEl)
+
+  if (!usernameEl) {
+    return
+  }
+
+  let username = usernameEl.textContent
+  console.log(username)
+  let uri = `https://twitch-extension.danielheart.dev/settings/${username}`
+
+  fetch(uri)
+    .then(async (response) => {
+      if (!response.ok) {
         return
-    }
+      }
 
-    console.log(mutations);
-    let messageEl = null;
-    for (let mutation of mutations) {
-        let isChildList = mutation.type === 'childList';
+      let res = await response.json()
+      console.log(res)
 
-        if (!isChildList) {
-            console.log('Not a childList mutation');
-            continue;
-        }
+      const child = usernameEl.firstChild
 
-        const addedNode = mutation.addedNodes[0];
-        if (!(addedNode instanceof HTMLElement)) {
-            continue;
-        }
+      const pronouns = res.pronouns
+      const pronounsElement = document.createElement("span")
+      pronounsElement.textContent = `(${pronouns})`
+      pronounsElement.style.color = "gray"
+      pronounsElement.style.marginLeft = "4px"
+      if (child) {
+        usernameEl.appendChild(pronounsElement)
+        badgesEl.appendChild(buildBadge(res.occupation), badgesEl.firstChild)
+      }
+    })
+    .catch((err) => console.error(err))
 
-        const isMessageEl = addedNode.classList.contains('chat-line__message');
-        if (!isMessageEl) {
-            continue;
-        }
-
-        messageEl = addedNode;
-        break;
-    }
-
-    if (messageEl === null) {
-        return;
-    }
-
-    let usernameEl = messageEl.querySelector('.chat-line__username');
-    let badgesEl = messageEl.querySelector('.chat-line__username-container').childNodes[0];
-
-    console.log(badgesEl);
-
-    if (!usernameEl) {
-        return;
-    }
-
-    let username = usernameEl.textContent;
-    console.log(username);
-    let uri = `https://twitch-extension.danielheart.dev/settings/${username}`;
-
-    fetch(uri)
-        .then(async response => {
-            if (!response.ok) {
-                return
-            }
-
-            let res = await response.json();
-            console.log(res)
-
-            const child = usernameEl.firstChild;
-
-            const pronouns = res.pronouns;
-            const pronounsElement = document.createElement('span');
-            pronounsElement.textContent = `(${pronouns})`;
-            pronounsElement.style.color = "gray";
-            pronounsElement.style.marginLeft = "4px";
-            if (child) {
-                usernameEl.appendChild(pronounsElement);
-                badgesEl.appendChild(buildBadge(res.occupation), badgesEl.firstChild);
-            }
-        }).catch(err => console.error(err));
-
-    messageEl = null;
-});
+  messageEl = null
+})
 
 const appLoader = () => {
-    console.log('TBP: Loading Twitch Better Profile...')
-    let chat = document.querySelector('.chat-list--default');
-    if (!chat) {
-        return setTimeout(appLoader, 3000);
-    }
+  console.log("TBP: Loading Twitch Better Profile...")
+  let chat = document.querySelector(".chat-list--default")
+  if (!chat) {
+    return setTimeout(appLoader, 3000)
+  }
 
-    console.log("TBP: Loaded! Starting to listen to new messages...");
-    const mutationConfig = {childList: true, subtree: true, characterData: true};
-    mutation.observe(chat, mutationConfig);
+  console.log("TBP: Loaded! Starting to listen to new messages...")
+  const mutationConfig = {
+    childList: true,
+    subtree: true,
+    characterData: true
+  }
+  mutation.observe(chat, mutationConfig)
 }
 
 setTimeout(appLoader, 3000)
-
-

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -111,16 +111,14 @@ let mutation = new MutationObserver((mutations) => {
     messageEl = null;
 });
 
-console.log('puta que pariu funciona')
-
 const appLoader = () => {
-    console.log('carregou')
+    console.log('TBP: Loading Twitch Better Profile...')
     let chat = document.querySelector('.chat-list--default');
     if (!chat) {
         return setTimeout(appLoader, 3000);
     }
 
-    console.log("observer on");
+    console.log("TBP: Loaded! Starting to listen to new messages...");
     const mutationConfig = {childList: true, subtree: true, characterData: true};
     mutation.observe(chat, mutationConfig);
 }

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -1,32 +1,32 @@
 import "~style.css"
-import {Auth} from "@Pages/auth";
-import {ThemeProvider} from "@Components/app/theme-provide";
-import {useEffect, useState} from "react";
-import Profile from "@Pages/profile";
-import type {TwitchUser} from "~types/types";
+
+import { ThemeProvider } from "@Components/app/theme-provide"
+import { Auth } from "@Pages/auth"
+import Profile from "@Pages/profile"
+import { useEffect, useState } from "react"
+
+import type { TwitchUser } from "~types/types"
 
 function IndexPopup() {
-    let [user, setUser] = useState(null)
+  let [user, setUser] = useState(null)
 
-    async function getUser() {
-        return browser.storage.local.get('user')
-    }
+  async function getUser() {
+    return browser.storage.local.get("user")
+  }
 
-    useEffect(() => {
-        getUser().then((res) => {
-            setUser(res.user as TwitchUser)
-        })
-    }, [])
+  useEffect(() => {
+    getUser().then((res) => {
+      setUser(res.user as TwitchUser)
+    })
+  }, [])
 
-    return (
-        <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-            <div className="min-w-[350px]">
-                {
-                    user ? <Profile user={user}/> : <Auth/>
-                }
-            </div>
-        </ThemeProvider>
-    )
+  return (
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <div className="min-w-[350px]">
+        {user ? <Profile user={user} /> : <Auth />}
+      </div>
+    </ThemeProvider>
+  )
 }
 
 export default IndexPopup

--- a/extension/src/resources/components/app/header.tsx
+++ b/extension/src/resources/components/app/header.tsx
@@ -1,16 +1,15 @@
-import {User as UserIcon} from "lucide-react";
-import {H4} from "@Shad/components/ui/typography/h4";
-import {ModeToggle} from "@Components/app/mode-toggle";
+import { ModeToggle } from "@Components/app/mode-toggle"
+import { H4 } from "@Shad/components/ui/typography/h4"
+import { User as UserIcon } from "lucide-react"
 
 export default function Header() {
-
-    return (
-        <div className="flex my-2 flex-row justify-between px-3 items-center">
-            <div className="flex flex-row">
-                <UserIcon/>
-                <H4>Twitch Profiler</H4>
-            </div>
-            <ModeToggle/>
-        </div>
-    )
+  return (
+    <div className="flex my-2 flex-row justify-between px-3 items-center">
+      <div className="flex flex-row">
+        <UserIcon />
+        <H4>Twitch Profiler</H4>
+      </div>
+      <ModeToggle />
+    </div>
+  )
 }

--- a/extension/src/resources/components/app/mode-toggle.tsx
+++ b/extension/src/resources/components/app/mode-toggle.tsx
@@ -1,37 +1,36 @@
-import { Moon, Sun } from "lucide-react"
-
+import { useTheme } from "@Components/app/theme-provide"
 import { Button } from "@Shad/components/ui/button"
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
 } from "@Shad/components/ui/dropdown-menu"
-import { useTheme } from "@Components/app/theme-provide"
+import { Moon, Sun } from "lucide-react"
 
 export function ModeToggle() {
-    const { setTheme } = useTheme()
+  const { setTheme } = useTheme()
 
-    return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="icon">
-                    <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                    <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-                    <span className="sr-only">Toggle theme</span>
-                </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setTheme("light")}>
-                    Light
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme("dark")}>
-                    Dark
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme("system")}>
-                    System
-                </DropdownMenuItem>
-            </DropdownMenuContent>
-        </DropdownMenu>
-    )
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
 }

--- a/extension/src/resources/components/app/theme-provide.tsx
+++ b/extension/src/resources/components/app/theme-provide.tsx
@@ -3,71 +3,71 @@ import { createContext, useContext, useEffect, useState } from "react"
 type Theme = "dark" | "light" | "system"
 
 type ThemeProviderProps = {
-    children: React.ReactNode
-    defaultTheme?: Theme
-    storageKey?: string
+  children: React.ReactNode
+  defaultTheme?: Theme
+  storageKey?: string
 }
 
 type ThemeProviderState = {
-    theme: Theme
-    setTheme: (theme: Theme) => void
+  theme: Theme
+  setTheme: (theme: Theme) => void
 }
 
 const initialState: ThemeProviderState = {
-    theme: "system",
-    setTheme: () => null,
+  theme: "system",
+  setTheme: () => null
 }
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
 
 export function ThemeProvider({
-                                  children,
-                                  defaultTheme = "system",
-                                  storageKey = "vite-ui-theme",
-                                  ...props
-                              }: ThemeProviderProps) {
-    const [theme, setTheme] = useState<Theme>(
-        () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
-    )
+  children,
+  defaultTheme = "system",
+  storageKey = "vite-ui-theme",
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  )
 
-    useEffect(() => {
-        const root = window.document.documentElement
+  useEffect(() => {
+    const root = window.document.documentElement
 
-        root.classList.remove("light", "dark")
+    root.classList.remove("light", "dark")
 
-        if (theme === "system") {
-            const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-                .matches
-                ? "dark"
-                : "light"
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light"
 
-            root.classList.add(systemTheme)
-            return
-        }
-
-        root.classList.add(theme)
-    }, [theme])
-
-    const value = {
-        theme,
-        setTheme: (theme: Theme) => {
-            localStorage.setItem(storageKey, theme)
-            setTheme(theme)
-        },
+      root.classList.add(systemTheme)
+      return
     }
 
-    return (
-        <ThemeProviderContext.Provider {...props} value={value}>
-            {children}
-        </ThemeProviderContext.Provider>
-    )
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    }
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
 }
 
 export const useTheme = () => {
-    const context = useContext(ThemeProviderContext)
+  const context = useContext(ThemeProviderContext)
 
-    if (context === undefined)
-        throw new Error("useTheme must be used within a ThemeProvider")
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider")
 
-    return context
+  return context
 }

--- a/extension/src/resources/components/auth/authenticate-button.tsx
+++ b/extension/src/resources/components/auth/authenticate-button.tsx
@@ -1,26 +1,22 @@
-import {Button} from "@Shad/components/ui/button";
-import {LucideTwitch} from "lucide-react";
-import {sendToBackground} from "@plasmohq/messaging"
+import { Button } from "@Shad/components/ui/button"
+import { LucideTwitch } from "lucide-react"
 
+import { sendToBackground } from "@plasmohq/messaging"
 
 export default function AuthenticateButton() {
+  const authenticate = async () => {
+    console.log("authenticate")
+    await sendToBackground({
+      name: "oauth"
+    })
+  }
 
-    const authenticate = async () => {
-        console.log('authenticate')
-        await sendToBackground({
-            name: "oauth",
-        })
-    }
-
-
-    return (
-        <div className="flex flex-row justify-center w-full">
-            <Button onClick={authenticate} style={{width: 250, marginBottom: 32}}>
-                <LucideTwitch/>
-                <p style={{paddingLeft: 10}}>
-                    Authenticate with Twitch
-                </p>
-            </Button>
-        </div>
-    )
+  return (
+    <div className="flex flex-row justify-center w-full">
+      <Button onClick={authenticate} style={{ width: 250, marginBottom: 32 }}>
+        <LucideTwitch />
+        <p style={{ paddingLeft: 10 }}>Authenticate with Twitch</p>
+      </Button>
+    </div>
+  )
 }

--- a/extension/src/resources/components/auth/hero.tsx
+++ b/extension/src/resources/components/auth/hero.tsx
@@ -1,11 +1,13 @@
-import React from "react";
+import React from "react"
 
-export default function Hero({children}: { children?: React.ReactNode }) {
-    return (
-        <div className="flex flex-col items-center justify-center" style={{marginTop: 32, marginBottom: 32}}>
-            <h1 className="text-4xl font-semibold">Twitch Profiler</h1>
-            <p className="text-lg font-light">Sign in with Twitch to get started</p>
-            {children}
-        </div>
-    );
+export default function Hero({ children }: { children?: React.ReactNode }) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center"
+      style={{ marginTop: 32, marginBottom: 32 }}>
+      <h1 className="text-4xl font-semibold">Twitch Profiler</h1>
+      <p className="text-lg font-light">Sign in with Twitch to get started</p>
+      {children}
+    </div>
+  )
 }

--- a/extension/src/resources/components/settings/profile-card.tsx
+++ b/extension/src/resources/components/settings/profile-card.tsx
@@ -1,33 +1,47 @@
-import type {TwitchUser} from "~types/types";
+import type { TwitchUser } from "~types/types"
 
 type ProfileCardProps = {
-    user: TwitchUser,
-    pronouns?: string,
-    occupation?: string
+  user: TwitchUser
+  pronouns?: string
+  occupation?: string
 }
 
-
-export default function ProfileCard({user, pronouns, occupation}: ProfileCardProps) {
-
-    return (
-        <div className="flex gap-4 mx-4 my-4">
-            <img src={user.profile_image_url} alt="Profile Image" className="size-28 rounded-3xl p-1"/>
-            <div>
-                <div className="flex flex-col">
-                    <h1 className="text-white font-extrabold text-lg m-0" id="usernameEl">{user.display_name}</h1>
-                    <p className="text-gray-400 text-lg m-0 p-0" id="roleEl">{ occupation ?? 'None'}</p>
-                </div>
-                <div className="mt-2">
-                    <p className="text-white font-extrabold text-sm">
-                        <span> ID: </span>
-                        <span className="text-gray-400 ml-2" id="idEl">{user.id}</span>
-                    </p>
-                    <p className="text-white font-extrabold text-sm">
-                        <span> Pronouns: </span>
-                        <span className="text-gray-400 ml-2" id="pronounsEl">{pronouns}</span>
-                    </p>
-                </div>
-            </div>
+export default function ProfileCard({
+  user,
+  pronouns,
+  occupation
+}: ProfileCardProps) {
+  return (
+    <div className="flex gap-4 mx-4 my-4">
+      <img
+        src={user.profile_image_url}
+        alt="Profile Image"
+        className="size-28 rounded-3xl p-1"
+      />
+      <div>
+        <div className="flex flex-col">
+          <h1 className="text-white font-extrabold text-lg m-0" id="usernameEl">
+            {user.display_name}
+          </h1>
+          <p className="text-gray-400 text-lg m-0 p-0" id="roleEl">
+            {occupation ?? "None"}
+          </p>
         </div>
-    );
+        <div className="mt-2">
+          <p className="text-white font-extrabold text-sm">
+            <span> ID: </span>
+            <span className="text-gray-400 ml-2" id="idEl">
+              {user.id}
+            </span>
+          </p>
+          <p className="text-white font-extrabold text-sm">
+            <span> Pronouns: </span>
+            <span className="text-gray-400 ml-2" id="pronounsEl">
+              {pronouns}
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/extension/src/resources/components/settings/settings-form.tsx
+++ b/extension/src/resources/components/settings/settings-form.tsx
@@ -1,96 +1,107 @@
-import {Card, CardContent} from "@Shad/components/ui/card";
-import {Label} from "@Shad/components/ui/label";
-import {type MutableRefObject, useRef} from "react";
-import type {TwitchUser} from "~types/types";
+import { Card, CardContent } from "@Shad/components/ui/card"
+import { Label } from "@Shad/components/ui/label"
+import { useRef, type MutableRefObject } from "react"
+
+import type { TwitchUser } from "~types/types"
 
 interface SettingsFormProps {
-    user?: TwitchUser,
-    pronouns?: string,
-    setPronoun?: (value: (((prevState: string) => string) | string)) => void,
-    setOccupation?: (value: (((prevState: string) => string) | string)) => void,
-    occupation?: string
+  user?: TwitchUser
+  pronouns?: string
+  setPronoun?: (value: ((prevState: string) => string) | string) => void
+  setOccupation?: (value: ((prevState: string) => string) | string) => void
+  occupation?: string
 }
 
-export default function SettingsForm({user, pronouns, setPronoun, setOccupation, occupation}: SettingsFormProps) {
+export default function SettingsForm({
+  user,
+  pronouns,
+  setPronoun,
+  setOccupation,
+  occupation
+}: SettingsFormProps) {
+  let pronounsListEl: MutableRefObject<HTMLSelectElement> = useRef(null)
+  let occupationListEl: MutableRefObject<HTMLSelectElement> = useRef(null)
 
-    let pronounsListEl: MutableRefObject<HTMLSelectElement> = useRef(null);
-    let occupationListEl: MutableRefObject<HTMLSelectElement> = useRef(null);
+  const occupations = [
+    "none",
+    "Student",
+    "Lawyer",
+    "Doctor",
+    "Civil Engineer",
+    "Front-end Engineer",
+    "SRE Engineer",
+    "Back-end Engineer",
+    "Fullstack Engineer"
+  ]
 
-    const occupations = [
-        'none',
-        'Student',
-        'Lawyer',
-        'Doctor',
-        'Civil Engineer',
-        'Front-end Engineer',
-        'SRE Engineer',
-        'Back-end Engineer',
-        'Fullstack Engineer'
-    ];
-
-    let updateSettings = async () => {
-        console.log('Updating pronouns')
-        let selectedPronoun = pronounsListEl.current.value;
-        let selectedOccupation = occupationListEl.current.value;
-        let response = await fetch('https://twitch-extension.danielheart.dev/settings', {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                pronouns: selectedPronoun,
-                locale: 'en-US',
-                occupation: selectedOccupation,
-                user_id: user.id,
-                username: user.display_name
-            })
+  let updateSettings = async () => {
+    console.log("Updating pronouns")
+    let selectedPronoun = pronounsListEl.current.value
+    let selectedOccupation = occupationListEl.current.value
+    let response = await fetch(
+      "https://twitch-extension.danielheart.dev/settings",
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          pronouns: selectedPronoun,
+          locale: "en-US",
+          occupation: selectedOccupation,
+          user_id: user.id,
+          username: user.display_name
         })
-
-        localStorage.setItem('pronouns', selectedPronoun);
-        localStorage.setItem('occupation', selectedOccupation);
-
-        if (response.ok) {
-            setPronoun(selectedPronoun);
-            setOccupation(selectedOccupation);
-        }
-    }
-
-    return (
-        <Card>
-            <CardContent>
-                <form>
-                    <div className="grid w-full items-center gap-4">
-                        <div className="flex flex-col space-y-1.5">
-                            <Label htmlFor="pronouns">Select your pronoun</Label>
-                            <select
-                                ref={pronounsListEl}
-                                id="pronouns"
-                                onChange={updateSettings}
-                                value={pronouns}
-                                className="flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300">
-                                <option value="N/D">None</option>
-                                <option value="He/Him">He/Him</option>
-                                <option value="She/Her">She/Her</option>
-                                <option value="They/Them">They/Them</option>
-                            </select>
-                        </div>
-
-                        <div className="flex flex-col space-y-1.5">
-                            <Label htmlFor="pronouns">Select your occupation</Label>
-                            <select
-                                ref={occupationListEl}
-                                id="pronouns"
-                                onChange={updateSettings}
-                                value={occupation}
-                                className="flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300">
-                                {occupations.map((occupationItem) => (
-                                    <option key={occupationItem} value={occupationItem}>{occupationItem}</option>
-                                ))}
-                            </select>
-                        </div>
-                    </div>
-                </form>
-            </CardContent>
-        </Card>
+      }
     )
+
+    localStorage.setItem("pronouns", selectedPronoun)
+    localStorage.setItem("occupation", selectedOccupation)
+
+    if (response.ok) {
+      setPronoun(selectedPronoun)
+      setOccupation(selectedOccupation)
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent>
+        <form>
+          <div className="grid w-full items-center gap-4">
+            <div className="flex flex-col space-y-1.5">
+              <Label htmlFor="pronouns">Select your pronoun</Label>
+              <select
+                ref={pronounsListEl}
+                id="pronouns"
+                onChange={updateSettings}
+                value={pronouns}
+                className="flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300">
+                <option value="N/D">None</option>
+                <option value="He/Him">He/Him</option>
+                <option value="She/Her">She/Her</option>
+                <option value="They/Them">They/Them</option>
+              </select>
+            </div>
+
+            <div className="flex flex-col space-y-1.5">
+              <Label htmlFor="pronouns">Select your occupation</Label>
+              <select
+                ref={occupationListEl}
+                id="pronouns"
+                onChange={updateSettings}
+                value={occupation}
+                className="flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300">
+                {occupations.map((occupationItem) => (
+                  <option key={occupationItem} value={occupationItem}>
+                    {occupationItem}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
 }

--- a/extension/src/resources/pages/auth.tsx
+++ b/extension/src/resources/pages/auth.tsx
@@ -1,15 +1,13 @@
-import Header from "@Components/app/header";
-import Hero from "@Components/auth/hero";
-import AuthenticateButton from "@Components/auth/authenticate-button";
-
+import Header from "@Components/app/header"
+import AuthenticateButton from "@Components/auth/authenticate-button"
+import Hero from "@Components/auth/hero"
 
 export const Auth = () => {
-    return (
-        <div className="flex flex-col">
-            <Header/>
-            <Hero>
-            </Hero>
-            <AuthenticateButton/>
-        </div>
-    )
+  return (
+    <div className="flex flex-col">
+      <Header />
+      <Hero></Hero>
+      <AuthenticateButton />
+    </div>
+  )
 }

--- a/extension/src/resources/pages/profile.tsx
+++ b/extension/src/resources/pages/profile.tsx
@@ -1,36 +1,41 @@
-import Header from "@Components/app/header";
-import ProfileCard from "@Components/settings/profile-card";
-import type {TwitchUser} from "~types/types";
-import SettingsForm from "@Components/settings/settings-form";
-import {useState} from "react";
+import Header from "@Components/app/header"
+import ProfileCard from "@Components/settings/profile-card"
+import SettingsForm from "@Components/settings/settings-form"
+import { useState } from "react"
+
+import type { TwitchUser } from "~types/types"
 
 type ProfileProps = {
-    user: TwitchUser
+  user: TwitchUser
 }
 
-export default function Profile({user}: ProfileProps) {
-    const [currentPronouns, setCurrentPronoun] = useState(localStorage.getItem('pronouns'));
-    const [currentOccupation, setCurrentOccupation] = useState(localStorage.getItem('occupation'));
+export default function Profile({ user }: ProfileProps) {
+  const [currentPronouns, setCurrentPronoun] = useState(
+    localStorage.getItem("pronouns")
+  )
+  const [currentOccupation, setCurrentOccupation] = useState(
+    localStorage.getItem("occupation")
+  )
 
-    return (
-        <div>
-            <Header/>
-            <div>
-                <ProfileCard
-                    user={user}
-                    pronouns={currentPronouns}
-                    occupation={currentOccupation}
-                />
-            </div>
-            <div className="py-30 px-3 my-4">
-                <SettingsForm
-                    user={user}
-                    pronouns={currentPronouns}
-                    setPronoun={setCurrentPronoun}
-                    occupation={currentOccupation}
-                    setOccupation={setCurrentOccupation}
-                />
-            </div>
-        </div>
-    );
+  return (
+    <div>
+      <Header />
+      <div>
+        <ProfileCard
+          user={user}
+          pronouns={currentPronouns}
+          occupation={currentOccupation}
+        />
+      </div>
+      <div className="py-30 px-3 my-4">
+        <SettingsForm
+          user={user}
+          pronouns={currentPronouns}
+          setPronoun={setCurrentPronoun}
+          occupation={currentOccupation}
+          setOccupation={setCurrentOccupation}
+        />
+      </div>
+    </div>
+  )
 }

--- a/extension/src/resources/shad/components/ui/button.tsx
+++ b/extension/src/resources/shad/components/ui/button.tsx
@@ -1,8 +1,7 @@
-import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
-
 import { cn } from "@Shad/lib/utils"
+import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
@@ -17,19 +16,19 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-primary underline-offset-4 hover:underline"
       },
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
-      },
+        icon: "h-10 w-10"
+      }
     },
     defaultVariants: {
       variant: "default",
-      size: "default",
-    },
+      size: "default"
+    }
   }
 )
 

--- a/extension/src/resources/shad/components/ui/card.tsx
+++ b/extension/src/resources/shad/components/ui/card.tsx
@@ -1,6 +1,5 @@
-import * as React from "react"
-
 import { cn } from "@Shad/lib/utils"
+import * as React from "react"
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/extension/src/resources/shad/components/ui/dialog.tsx
+++ b/extension/src/resources/shad/components/ui/dialog.tsx
@@ -1,8 +1,7 @@
-import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
-
 import { cn } from "@Shad/lib/utils"
+import { X } from "lucide-react"
+import * as React from "react"
 
 const Dialog = DialogPrimitive.Root
 
@@ -39,8 +38,7 @@ const DialogContent = React.forwardRef<
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-slate-800 dark:bg-slate-950",
         className
       )}
-      {...props}
-    >
+      {...props}>
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-slate-100 data-[state=open]:text-slate-500 dark:ring-offset-slate-950 dark:focus:ring-slate-300 dark:data-[state=open]:bg-slate-800 dark:data-[state=open]:text-slate-400">
         <X className="h-4 w-4" />
@@ -116,5 +114,5 @@ export {
   DialogHeader,
   DialogFooter,
   DialogTitle,
-  DialogDescription,
+  DialogDescription
 }

--- a/extension/src/resources/shad/components/ui/dropdown-menu.tsx
+++ b/extension/src/resources/shad/components/ui/dropdown-menu.tsx
@@ -1,8 +1,7 @@
-import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { Check, ChevronRight, Circle } from "lucide-react"
-
 import { cn } from "@Shad/lib/utils"
+import { Check, ChevronRight, Circle } from "lucide-react"
+import * as React from "react"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -29,8 +28,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
       inset && "pl-8",
       className
     )}
-    {...props}
-  >
+    {...props}>
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
   </DropdownMenuPrimitive.SubTrigger>
@@ -101,8 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       className
     )}
     checked={checked}
-    {...props}
-  >
+    {...props}>
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
@@ -124,8 +121,7 @@ const DropdownMenuRadioItem = React.forwardRef<
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
-    {...props}
-  >
+    {...props}>
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
         <Circle className="h-2 w-2 fill-current" />
@@ -194,5 +190,5 @@ export {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
+  DropdownMenuRadioGroup
 }

--- a/extension/src/resources/shad/components/ui/input.tsx
+++ b/extension/src/resources/shad/components/ui/input.tsx
@@ -1,6 +1,5 @@
-import * as React from "react"
-
 import { cn } from "@Shad/lib/utils"
+import * as React from "react"
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/extension/src/resources/shad/components/ui/label.tsx
+++ b/extension/src/resources/shad/components/ui/label.tsx
@@ -1,8 +1,7 @@
-import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
-
 import { cn } from "@Shad/lib/utils"
+import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"

--- a/extension/src/resources/shad/components/ui/typography/h1.tsx
+++ b/extension/src/resources/shad/components/ui/typography/h1.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React from "react"
 
-export function H1({children}: { children: React.ReactNode }) {
-    return (
-        <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
-            {children}
-        </h1>
-    )
+export function H1({ children }: { children: React.ReactNode }) {
+  return (
+    <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
+      {children}
+    </h1>
+  )
 }

--- a/extension/src/resources/shad/components/ui/typography/h2.tsx
+++ b/extension/src/resources/shad/components/ui/typography/h2.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React from "react"
 
-export function H2({children}: { children: React.ReactNode }) {
-    return (
-        <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
-            {children}
-        </h2>
-    )
+export function H2({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
+      {children}
+    </h2>
+  )
 }

--- a/extension/src/resources/shad/components/ui/typography/h3.tsx
+++ b/extension/src/resources/shad/components/ui/typography/h3.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React from "react"
 
-export function H3({children}: { children: React.ReactNode }) {
-    return (
-        <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">
-            {children}
-        </h3>
-    )
+export function H3({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+      {children}
+    </h3>
+  )
 }

--- a/extension/src/resources/shad/components/ui/typography/h4.tsx
+++ b/extension/src/resources/shad/components/ui/typography/h4.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React from "react"
 
-export function H4({children}: { children: React.ReactNode }) {
-    return (
-        <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
-            {children}
-        </h4>
-    )
+export function H4({ children }: { children: React.ReactNode }) {
+  return (
+    <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
+      {children}
+    </h4>
+  )
 }

--- a/extension/src/resources/shad/lib/utils.ts
+++ b/extension/src/resources/shad/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type ClassValue, clsx } from "clsx"
+import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {

--- a/extension/src/types/types.d.ts
+++ b/extension/src/types/types.d.ts
@@ -1,13 +1,13 @@
 export interface TwitchUser {
-    id: number
-    login: string
-    display_name: string
-    type: string
-    broadcaster_type: string
-    description: string
-    profile_image_url: string
-    offline_image_url: string
-    view_count: number
-    email: string
-    created_at: string
+  id: number
+  login: string
+  display_name: string
+  type: string
+  broadcaster_type: string
+  description: string
+  profile_image_url: string
+  offline_image_url: string
+  view_count: number
+  email: string
+  created_at: string
 }


### PR DESCRIPTION
## Motivation

After the release of 0.0.3 we saw that the plugin was only loaded in one page per browser due each page loading time.

Currently the goal is to support:
- Streamer Dashboard - dashboard.twitch.tv/*
- Twitch Streamer Page - twitch.tv/*
- Embed Chats - twitch.tv/embed/*

## Fixes

I've tried to add EventListeners on window but still not working properly. After that I just decided to implement a small recursion to start to listen when the page is fully loaded.

- Added setInterval(() => {}, 3000 for the targeted pages.

