### PR TITLE
feat: add i18n support with English and Brazilian Portuguese translations

### DIFF
--- a/extension/locales/en/messages.json
+++ b/extension/locales/en/messages.json
@@ -1,0 +1,77 @@
+{
+  "logoutButtonText": {
+    "message": "Logout"
+  },
+  "toggleTheme": {
+    "message": "Toggle theme"
+  },
+  "themeLight": {
+    "message": "Light"
+  },
+  "themeDark": {
+    "message": "Dark"
+  },
+  "themeSystem": {
+    "message": "System"
+  },
+  "headerTitle": {
+    "message": "Twitch Profiler"
+  },
+  "authenticateButtonText": {
+    "message": "Authenticate with Twitch"
+  },
+  "heroTitle": {
+    "message": "Twitch Profiler"
+  },
+  "heroSubtitle": {
+    "message": "Sign in with Twitch to get started"
+  },
+  "pronounsLabel": {
+    "message": "Select your pronoun"
+  },
+  "occupationLabel": {
+    "message": "Select your occupation"
+  },
+  "pronounsTitle": {
+    "message": "Pronouns"
+  },
+  "pronounsNone": {
+    "message": "None"
+  },
+  "pronounsHeHim": {
+    "message": "He/His"
+  },
+  "pronounsSheHer": {
+    "message": "She/Her"
+  },
+  "pronounsTheyThem": {
+    "message": "They/Them"
+  },
+  "occupationNone": {
+    "message": "None"
+  },
+  "occupationStudent": {
+    "message": "Student"
+  },
+  "occupationLawyer": {
+    "message": "Lawyer"
+  },
+  "occupationDoctor": {
+    "message": "Doctor"
+  },
+  "occupationCivilEngineer": {
+    "message": "Civil engineer"
+  },
+  "occupationFrontEndEngineer": {
+    "message": "Front-end engineer"
+  },
+  "occupationSreEngineer": {
+    "message": "SRE engineer"
+  },
+  "occupationBackEndEngineer": {
+    "message": "Back-end engineer"
+  },
+  "occupationFullstackEngineer": {
+    "message": "Full-stack engineer"
+  }
+}

--- a/extension/locales/pt_BR/messages.json
+++ b/extension/locales/pt_BR/messages.json
@@ -60,13 +60,13 @@
     "message": "Médico"
   },
   "occupationCivilEngineer": {
-    "message": "Desenvolvedor Civil"
+    "message": "Engenheiro Civil"
   },
   "occupationFrontEndEngineer": {
     "message": "Desenvolvedor Front-end"
   },
   "occupationSreEngineer": {
-    "message": "Desenvolvedor SRE"
+    "message": "SRE"
   },
   "occupationBackEndEngineer": {
     "message": "Desenvolvedor Back-end"

--- a/extension/locales/pt_BR/messages.json
+++ b/extension/locales/pt_BR/messages.json
@@ -1,0 +1,77 @@
+{
+  "logoutButtonText": {
+    "message": "Sair"
+  },
+  "toggleTheme": {
+    "message": "Alternar tema"
+  },
+  "themeLight": {
+    "message": "Claro"
+  },
+  "themeDark": {
+    "message": "Escuro"
+  },
+  "themeSystem": {
+    "message": "Sistema"
+  },
+  "headerTitle": {
+    "message": "Perfil da Twitch"
+  },
+  "authenticateButtonText": {
+    "message": "Autenticar com a Twitch"
+  },
+  "heroTitle": {
+    "message": "Perfil da Twitch"
+  },
+  "heroSubtitle": {
+    "message": "Faça login com a Twitch para começar"
+  },
+  "pronounsLabel": {
+    "message": "Selecione seu pronome"
+  },
+  "occupationLabel": {
+    "message": "Selecione sua ocupação"
+  },
+  "pronounsTitle": {
+    "message": "Pronomes"
+  },
+  "pronounsNone": {
+    "message": "Nenhum"
+  },
+  "pronounsHeHim": {
+    "message": "Ele/Dele"
+  },
+  "pronounsSheHer": {
+    "message": "Ela/Dela"
+  },
+  "pronounsTheyThem": {
+    "message": "Eles/Deles"
+  },
+  "occupationNone": {
+    "message": "Nenhum"
+  },
+  "occupationStudent": {
+    "message": "Estudante"
+  },
+  "occupationLawyer": {
+    "message": "Advogado"
+  },
+  "occupationDoctor": {
+    "message": "Médico"
+  },
+  "occupationCivilEngineer": {
+    "message": "Desenvolvedor Civil"
+  },
+  "occupationFrontEndEngineer": {
+    "message": "Desenvolvedor Front-end"
+  },
+  "occupationSreEngineer": {
+    "message": "Desenvolvedor SRE"
+  },
+  "occupationBackEndEngineer": {
+    "message": "Desenvolvedor Back-end"
+  },
+  "occupationFullstackEngineer": {
+    "message": "Desenvolvedor Full-stack"
+  }
+}

--- a/extension/locales/pt_BR/messages.json
+++ b/extension/locales/pt_BR/messages.json
@@ -30,7 +30,7 @@
     "message": "Selecione seu pronome"
   },
   "occupationLabel": {
-    "message": "Selecione sua ocupação"
+    "message": "Selecione sua profissão"
   },
   "pronounsTitle": {
     "message": "Pronomes"

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -1,6 +1,3 @@
-
-
-
 import "~style.css"
 
 import { ThemeProvider } from "@Components/app/theme-provide"
@@ -9,10 +6,6 @@ import Profile from "@Pages/profile"
 
 import { Storage } from "@plasmohq/storage"
 import { useStorage } from "@plasmohq/storage/dist/hook"
-
-
-
-
 
 const storage = new Storage()
 

--- a/extension/src/resources/components/app/header.tsx
+++ b/extension/src/resources/components/app/header.tsx
@@ -2,12 +2,14 @@ import { ModeToggle } from "@Components/app/mode-toggle"
 import { H4 } from "@Shad/components/ui/typography/h4"
 import { User as UserIcon } from "lucide-react"
 
+import { t } from "~utils/i18nUtils"
+
 export default function Header() {
   return (
     <div className="flex my-2 flex-row justify-between px-3 items-center">
       <div className="flex gap-2 dark:text-twitch-11">
         <UserIcon />
-        <H4>Twitch Profiler</H4>
+        <H4>{t("headerTitle")}</H4>
       </div>
       <ModeToggle />
     </div>

--- a/extension/src/resources/components/app/mode-toggle.tsx
+++ b/extension/src/resources/components/app/mode-toggle.tsx
@@ -8,6 +8,8 @@ import {
 } from "@Shad/components/ui/dropdown-menu"
 import { Moon, Sun } from "lucide-react"
 
+import { t } from "~utils/i18nUtils"
+
 export function ModeToggle() {
   const { setTheme } = useTheme()
 
@@ -17,18 +19,18 @@ export function ModeToggle() {
         <Button variant="outline" size="icon">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
+          <span className="sr-only">{t("toggleTheme")}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={() => setTheme("light")}>
-          Light
+          {t("themeLight")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Dark
+          {t("themeDark")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("system")}>
-          System
+          {t("themeSystem")}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/extension/src/resources/components/auth/authenticate-button.tsx
+++ b/extension/src/resources/components/auth/authenticate-button.tsx
@@ -3,6 +3,8 @@ import { LucideTwitch } from "lucide-react"
 
 import { sendToBackground } from "@plasmohq/messaging"
 
+import { t } from "~utils/i18nUtils"
+
 export default function AuthenticateButton() {
   const authenticate = async () => {
     console.log("authenticate")
@@ -15,7 +17,7 @@ export default function AuthenticateButton() {
     <div className="flex flex-row justify-center w-full">
       <Button onClick={authenticate} style={{ width: 250, marginBottom: 32 }}>
         <LucideTwitch />
-        <p style={{ paddingLeft: 10 }}>Authenticate with Twitch</p>
+        <p style={{ paddingLeft: 10 }}>{t("authenticateButtonText")}</p>
       </Button>
     </div>
   )

--- a/extension/src/resources/components/auth/hero.tsx
+++ b/extension/src/resources/components/auth/hero.tsx
@@ -1,12 +1,14 @@
 import React from "react"
 
+import { t } from "~utils/i18nUtils"
+
 export default function Hero({ children }: { children?: React.ReactNode }) {
   return (
     <div
       className="flex flex-col items-center justify-center"
       style={{ marginTop: 32, marginBottom: 32 }}>
-      <h1 className="text-4xl font-semibold">Twitch Profiler</h1>
-      <p className="text-lg font-light">Sign in with Twitch to get started</p>
+      <h1 className="text-4xl font-semibold">{t("heroTitle")}</h1>
+      <p className="text-lg font-light">{t("heroSubtitle")}</p>
       {children}
     </div>
   )

--- a/extension/src/resources/components/settings/profile-card.tsx
+++ b/extension/src/resources/components/settings/profile-card.tsx
@@ -1,4 +1,5 @@
 import type { TwitchUser } from "~types/types"
+import { t } from "~utils/i18nUtils"
 
 type ProfileCardProps = {
   user: TwitchUser
@@ -28,7 +29,7 @@ export default function ProfileCard({
           <p
             className="text-gray-600 dark:text-gray-300 text-sm m-0 p-0"
             id="roleEl">
-            {occupation ?? "None"}
+            {occupation ?? t("occupationNone")}
           </p>
         </div>
         <div className="mt-2">
@@ -39,7 +40,7 @@ export default function ProfileCard({
             </span>
           </p>
           <p className="text-sm">
-            <span className="font-bold">Pronouns:</span>
+            <span className="font-bold">{t("pronounsTitle")}:</span>
             <span
               className="text-gray-600 dark:text-gray-300 ml-2"
               id="pronounsEl">

--- a/extension/src/resources/components/settings/settings-form.tsx
+++ b/extension/src/resources/components/settings/settings-form.tsx
@@ -4,6 +4,7 @@ import { useRef, type MutableRefObject } from "react"
 import { Storage } from "@plasmohq/storage"
 
 import type { TwitchUser } from "~types/types"
+import { t } from "~utils/i18nUtils"
 
 interface SettingsFormProps {
   user?: TwitchUser
@@ -20,15 +21,15 @@ export default function SettingsForm({
   const occupationListEl: MutableRefObject<HTMLSelectElement> = useRef(null)
 
   const occupations = [
-    "none",
-    "Student",
-    "Lawyer",
-    "Doctor",
-    "Civil Engineer",
-    "Front-end Engineer",
-    "SRE Engineer",
-    "Back-end Engineer",
-    "Fullstack Engineer"
+    "occupationNone",
+    "occupationStudent",
+    "occupationLawyer",
+    "occupationDoctor",
+    "occupationCivilEngineer",
+    "occupationFrontEndEngineer",
+    "occupationSreEngineer",
+    "occupationBackEndEngineer",
+    "occupationFullstackEngineer"
   ]
 
   const updateSettings = async () => {
@@ -63,31 +64,33 @@ export default function SettingsForm({
     <form className="p-4 border rounded-lg">
       <div className="flex flex-col w-full items-center gap-4">
         <div className="flex flex-col gap-2 w-full">
-          <Label htmlFor="pronouns">Select your pronoun</Label>
+          <Label htmlFor="pronouns">{t("pronounsLabel")}</Label>
           <select
             ref={pronounsListEl}
             id="pronouns"
             onChange={updateSettings}
             value={pronouns}
             className="flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300">
-            <option value="N/D">None</option>
-            <option value="He/Him">He/Him</option>
-            <option value="She/Her">She/Her</option>
-            <option value="They/Them">They/Them</option>
+            <option value="N/D">{t("pronounsNone")}</option>
+            <option value={t("pronounsHeHim")}>{t("pronounsHeHim")}</option>
+            <option value={t("pronounsSheHer")}>{t("pronounsSheHer")}</option>
+            <option value={t("pronounsTheyThem")}>
+              {t("pronounsTheyThem")}
+            </option>
           </select>
         </div>
 
         <div className="flex flex-col gap-2 w-full">
-          <Label htmlFor="pronouns">Select your occupation</Label>
+          <Label htmlFor="occupation">{t("occupationLabel")}</Label>
           <select
             ref={occupationListEl}
             id="pronouns"
             onChange={updateSettings}
             value={occupation}
             className="flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300">
-            {occupations.map((occupationItem) => (
-              <option key={occupationItem} value={occupationItem}>
-                {occupationItem}
+            {occupations.map((occupationKey) => (
+              <option key={occupationKey} value={t(occupationKey)}>
+                {t(occupationKey)}
               </option>
             ))}
           </select>

--- a/extension/src/resources/pages/profile.tsx
+++ b/extension/src/resources/pages/profile.tsx
@@ -7,6 +7,7 @@ import { Storage } from "@plasmohq/storage"
 import { useStorage } from "@plasmohq/storage/dist/hook"
 
 import type { TwitchUser } from "~types/types"
+import { t } from "~utils/i18nUtils"
 
 type ProfileProps = {
   user: TwitchUser
@@ -35,11 +36,11 @@ export default function Profile({ user }: ProfileProps) {
         />
       </div>
       <Button
-          className={"w-full"}
+        className={"w-full"}
         onClick={() => {
           storage.clear()
         }}>
-        Logout
+        {t("logoutButtonText")}
       </Button>
     </div>
   )

--- a/extension/src/utils/i18nUtils.ts
+++ b/extension/src/utils/i18nUtils.ts
@@ -1,0 +1,3 @@
+export const t = (key: string): string => {
+  return chrome.i18n.getMessage(key) || key
+}


### PR DESCRIPTION
This pull request introduces internationalization support based on the browser's language settings. Currently, English and Brazilian Portuguese are available.

### Details

- Implemented internationalization (i18n) to dynamically adjust the interface language according to the user's browser settings.
- Added support for two languages: English (en-US) and Brazilian Portuguese (pt-BR).

![Peek 2024-08-04 04-19](https://github.com/user-attachments/assets/897854d5-38b9-4c74-a7f6-6165c74b5b07)
