### PR TITLE
feat: adding message queue

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,11 +1,8 @@
 import type { PlasmoCSConfig } from "plasmo"
-import browser from "webextension-polyfill"
 
-import { ChatMutationObserver } from "~scripting/observer"
+import { appLoader } from "~scripting"
 
 export {}
-
-const CHAT_LIST = ".chat-list--default,.chat-list--other,.chat-list"
 
 export const config: PlasmoCSConfig = {
   matches: [
@@ -23,34 +20,5 @@ export const config: PlasmoCSConfig = {
 }
 
 // @ts-ignore
-
-const appLoader = () => {
-  console.log("TBP: Loading Twitch Better Profile...")
-
-  let hasWelcomeMessageOnBody = document.body.querySelector(
-    'div[data-a-target="chat-welcome-message"]'
-  )
-
-  if (!hasWelcomeMessageOnBody) {
-    console.log("TBP: Welcome message not found, waiting...")
-    return setTimeout(appLoader, 3000)
-  }
-
-  let chatElements = document.querySelector(CHAT_LIST)
-  if (!chatElements) {
-    return setTimeout(appLoader, 3000)
-  }
-
-  let chat = chatElements as Node
-  console.log(chat)
-  console.log("TBP: Loaded! Starting to listen to new messages...")
-
-  let observer = new ChatMutationObserver()
-  observer.start(chat, {
-    childList: true,
-    subtree: true,
-    characterData: true
-  })
-}
 
 appLoader()

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,10 +1,11 @@
-// NOTE: [daniel-boll] - This appear to be necessary, I'll check this later with @danielhe4rt
-
 import type { PlasmoCSConfig } from "plasmo"
-import {t} from "~utils/i18nUtils";
+import browser from "webextension-polyfill"
 
-{
-}
+import { ChatMutationObserver } from "~scripting/observer"
+
+export {}
+
+const CHAT_LIST = ".chat-list--default,.chat-list--other,.chat-list"
 
 export const config: PlasmoCSConfig = {
   matches: [
@@ -22,111 +23,34 @@ export const config: PlasmoCSConfig = {
 }
 
 // @ts-ignore
-const API_URL: string = process.env.PLASMO_PUBLIC_API_URL
-
-const buildBadge = (_badge) => {
-  // Create a div element
-  const badgeContainer = document.createElement("div")
-  badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA"
-
-  // Create an img element
-  const img = document.createElement("img")
-  img.alt = "Just a thing"
-  img.width = 18
-  img.setAttribute("aria-label", "Just a thing")
-  img.className = "chat-badge"
-  img.src = `${API_URL}/static/icons/mod.png`
-  img.srcset = `${API_URL}/static/icons/mod.png 1x,${API_URL}/static/icons/mod.png 2x,${API_URL}/static/icons/mod.png 4x`
-
-  // Append the img to the div
-  badgeContainer.appendChild(img)
-
-  return badgeContainer
-}
-
-let mutation = new MutationObserver((mutations) => {
-  // @ts-ignore
-  if (mutations[0].previousSibling.localName === "span") {
-    return
-  }
-  let messageEl = null
-  for (let mutation of mutations) {
-    let isChildList = mutation.type === "childList"
-
-    if (!isChildList) {
-      console.log("Not a childList mutation")
-      continue
-    }
-
-    const addedNode = mutation.addedNodes[0]
-    if (!(addedNode instanceof HTMLElement)) {
-      continue
-    }
-
-    const isMessageEl = addedNode.classList.contains("chat-line__message")
-    if (!isMessageEl) {
-      continue
-    }
-
-    messageEl = addedNode
-    break
-  }
-
-  if (messageEl === null) {
-    return
-  }
-
-  let usernameEl = messageEl.querySelector(".chat-line__username")
-  let badgesEl = messageEl.querySelector(".chat-line__username-container")
-    .childNodes[0]
-
-  if (!usernameEl) {
-    return
-  }
-
-  let username = usernameEl.textContent
-  console.log(username)
-  let uri = `${API_URL}/settings/${username}`
-
-  fetch(uri)
-    .then(async (response) => {
-      if (!response.ok) {
-        return
-      }
-
-      let res = await response.json()
-      const child = usernameEl.firstChild
-
-      let pronouns = res.pronouns.replace("/", "")
-      let i18nPronouns = t("pronouns" + pronouns)
-      const pronounsElement = document.createElement("span")
-      pronounsElement.textContent = `(${i18nPronouns})`
-      pronounsElement.style.color = "gray"
-      pronounsElement.style.marginLeft = "4px"
-      if (child) {
-        usernameEl.appendChild(pronounsElement)
-        badgesEl.appendChild(buildBadge(res.occupation), badgesEl.firstChild)
-      }
-    })
-    .catch((err) => console.error(err))
-
-  messageEl = null
-})
 
 const appLoader = () => {
   console.log("TBP: Loading Twitch Better Profile...")
-  let chat = document.querySelector(".chat-list--default")
-  if (!chat) {
+
+  let hasWelcomeMessageOnBody = document.body.querySelector(
+    'div[data-a-target="chat-welcome-message"]'
+  )
+
+  if (!hasWelcomeMessageOnBody) {
+    console.log("TBP: Welcome message not found, waiting...")
     return setTimeout(appLoader, 3000)
   }
 
+  let chatElements = document.querySelector(CHAT_LIST)
+  if (!chatElements) {
+    return setTimeout(appLoader, 3000)
+  }
+
+  let chat = chatElements as Node
+  console.log(chat)
   console.log("TBP: Loaded! Starting to listen to new messages...")
-  const mutationConfig = {
+
+  let observer = new ChatMutationObserver()
+  observer.start(chat, {
     childList: true,
     subtree: true,
     characterData: true
-  }
-  mutation.observe(chat, mutationConfig)
+  })
 }
 
-setTimeout(appLoader, 3000)
+appLoader()

--- a/extension/src/scripting/components.ts
+++ b/extension/src/scripting/components.ts
@@ -1,0 +1,64 @@
+import {t} from "~utils/i18nUtils";
+
+const API_URL: string = process.env.PLASMO_PUBLIC_API_URL
+
+const enhanceChatMessage = (messageEl: HTMLElement) => {
+    let usernameEl = messageEl.querySelector(".chat-line__username")
+    let badgesEl = messageEl.querySelector(".chat-line__username-container")
+        .childNodes[0]
+
+    if (!usernameEl) {
+        return
+    }
+
+    let username = usernameEl.textContent
+    console.log(username)
+    let uri = `${API_URL}/settings/${username}`
+
+    fetch(uri)
+        .then(async (response) => {
+            if (!response.ok) {
+                return
+            }
+
+            let res = await response.json()
+            const child = usernameEl.firstChild
+
+            let pronouns = res.pronouns.replace("/", "")
+            let i18nPronouns = t("pronouns" + pronouns)
+            const pronounsElement = document.createElement("span")
+            pronounsElement.textContent = `(${i18nPronouns})`
+            pronounsElement.style.color = "gray"
+            pronounsElement.style.marginLeft = "4px"
+
+            if (child) {
+                usernameEl.appendChild(pronounsElement)
+                badgesEl.appendChild(buildBadge(res.occupation))
+            }
+        })
+        .catch((err) => {
+
+        })
+}
+
+const buildBadge = (_badge) => {
+    // Create a div element
+    const badgeContainer = document.createElement("div")
+    badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA"
+
+    // Create an img element
+    const img = document.createElement("img")
+    img.alt = "Just a thing"
+    img.width = 18
+    img.setAttribute("aria-label", "Just a thing")
+    img.className = "chat-badge"
+    img.src = `${API_URL}/static/icons/mod.png`
+    img.srcset = `${API_URL}/static/icons/mod.png 1x,${API_URL}/static/icons/mod.png 2x,${API_URL}/static/icons/mod.png 4x`
+
+    // Append the img to the div
+    badgeContainer.appendChild(img)
+
+    return badgeContainer
+}
+
+export {enhanceChatMessage}

--- a/extension/src/scripting/components.ts
+++ b/extension/src/scripting/components.ts
@@ -1,64 +1,64 @@
-import {t} from "~utils/i18nUtils";
+import { t } from "~utils/i18nUtils"
 
 const API_URL: string = process.env.PLASMO_PUBLIC_API_URL
 
-const enhanceChatMessage = (messageEl: HTMLElement) => {
-    let usernameEl = messageEl.querySelector(".chat-line__username")
-    let badgesEl = messageEl.querySelector(".chat-line__username-container")
-        .childNodes[0]
+const enhanceChatMessage = async (messageEl: HTMLElement) => {
+  console.log(messageEl.textContent);
+  let usernameEl = messageEl.querySelector(".chat-line__username")
+  let badgesEl = messageEl.querySelector(".chat-line__username-container");
 
-    if (!usernameEl) {
-        return
-    }
+  if (!badgesEl) {
+    return
+  }
+  badgesEl = badgesEl.childNodes[0] as Element;
 
-    let username = usernameEl.textContent
-    console.log(username)
-    let uri = `${API_URL}/settings/${username}`
+  if (!usernameEl) {
+    return
+  }
 
-    fetch(uri)
-        .then(async (response) => {
-            if (!response.ok) {
-                return
-            }
+  let username = usernameEl.textContent
+  let uri = `${API_URL}/settings/${username}`
+  let req = await fetch(uri)
 
-            let res = await response.json()
-            const child = usernameEl.firstChild
+  if (!req.ok) {
+    return
+  }
 
-            let pronouns = res.pronouns.replace("/", "")
-            let i18nPronouns = t("pronouns" + pronouns)
-            const pronounsElement = document.createElement("span")
-            pronounsElement.textContent = `(${i18nPronouns})`
-            pronounsElement.style.color = "gray"
-            pronounsElement.style.marginLeft = "4px"
+  let res = await req.json();
 
-            if (child) {
-                usernameEl.appendChild(pronounsElement)
-                badgesEl.appendChild(buildBadge(res.occupation))
-            }
-        })
-        .catch((err) => {
+  const child = usernameEl.firstChild
 
-        })
+  let pronouns = res.pronouns.replace("/", "")
+  let i18nPronouns = t("pronouns" + pronouns)
+  const pronounsElement = document.createElement("span")
+  pronounsElement.textContent = `(${i18nPronouns})`
+  pronounsElement.style.color = "gray"
+  pronounsElement.style.marginLeft = "4px"
+
+  if (child) {
+    usernameEl.appendChild(pronounsElement)
+    badgesEl.appendChild(buildBadge(res.occupation))
+  }
 }
 
 const buildBadge = (_badge) => {
-    // Create a div element
-    const badgeContainer = document.createElement("div")
-    badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA"
+  // Create a div element
+  const badgeContainer = document.createElement("div")
+  badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA"
 
-    // Create an img element
-    const img = document.createElement("img")
-    img.alt = "Just a thing"
-    img.width = 18
-    img.setAttribute("aria-label", "Just a thing")
-    img.className = "chat-badge"
-    img.src = `${API_URL}/static/icons/mod.png`
-    img.srcset = `${API_URL}/static/icons/mod.png 1x,${API_URL}/static/icons/mod.png 2x,${API_URL}/static/icons/mod.png 4x`
+  // Create an img element
+  const img = document.createElement("img")
+  img.alt = "Just a thing"
+  img.width = 18
+  img.setAttribute("aria-label", "Just a thing")
+  img.className = "chat-badge"
+  img.src = `${API_URL}/static/icons/mod.png`
+  img.srcset = `${API_URL}/static/icons/mod.png 1x,${API_URL}/static/icons/mod.png 2x,${API_URL}/static/icons/mod.png 4x`
 
-    // Append the img to the div
-    badgeContainer.appendChild(img)
+  // Append the img to the div
+  badgeContainer.appendChild(img)
 
-    return badgeContainer
+  return badgeContainer
 }
 
-export {enhanceChatMessage}
+export { enhanceChatMessage }

--- a/extension/src/scripting/index.ts
+++ b/extension/src/scripting/index.ts
@@ -1,0 +1,22 @@
+import { ChatMutation } from './observer';
+
+
+const CHAT_ELEMENTS = ".chat-list, .chat-list--default, .chat-list--other"
+
+const appLoader = () => {
+    console.log("TBP: Loading Twitch Better Profile...")
+    let chat = document.querySelectorAll(CHAT_ELEMENTS)
+
+    if (!chat) {
+        return setTimeout(appLoader, 3000)
+    }
+
+    console.log("TBP: Loaded! Starting to listen to new messages...")
+    const mutationConfig = {
+        childList: true,
+        subtree: true,
+        characterData: true
+    }
+
+    ChatMutation.observe(chat.item(0), mutationConfig)
+}

--- a/extension/src/scripting/index.ts
+++ b/extension/src/scripting/index.ts
@@ -1,22 +1,34 @@
-import { ChatMutation } from './observer';
+import { ChatMutationObserver } from "./observer"
 
-
-const CHAT_ELEMENTS = ".chat-list, .chat-list--default, .chat-list--other"
+const CHAT_LIST = ".chat-list--default,.chat-list--other,.chat-list"
 
 const appLoader = () => {
-    console.log("TBP: Loading Twitch Better Profile...")
-    let chat = document.querySelectorAll(CHAT_ELEMENTS)
+  console.log("TBP: Loading Twitch Better Profile...")
 
-    if (!chat) {
-        return setTimeout(appLoader, 3000)
-    }
+  let hasWelcomeMessageOnBody = document.body.querySelector(
+    'div[data-a-target="chat-welcome-message"]'
+  )
 
-    console.log("TBP: Loaded! Starting to listen to new messages...")
-    const mutationConfig = {
-        childList: true,
-        subtree: true,
-        characterData: true
-    }
+  if (!hasWelcomeMessageOnBody) {
+    console.log("TBP: Welcome message not found, waiting...")
+    return setTimeout(appLoader, 1000)
+  }
 
-    ChatMutation.observe(chat.item(0), mutationConfig)
+  let chatElements = document.querySelector(CHAT_LIST)
+  if (!chatElements) {
+    return setTimeout(appLoader, 3000)
+  }
+
+  let chat = chatElements as Node
+  console.log(chat)
+  console.log("TBP: Loaded! Starting to listen to new messages...")
+
+  let observer = new ChatMutationObserver()
+  observer.start(chat, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  })
 }
+
+export { appLoader }

--- a/extension/src/scripting/observer.ts
+++ b/extension/src/scripting/observer.ts
@@ -1,0 +1,88 @@
+import { MessageQueue } from "~scripting/queue"
+
+class ChatMutationObserver {
+  private observer: MutationObserver
+
+  private queue: MessageQueue
+  private messagesBatch: any[]
+  private debounceTimer: number
+  private processedNodes: Set<HTMLElement> = new Set()
+  private readonly debounceInterval: number
+
+  constructor() {
+    this.queue = new MessageQueue()
+    this.messagesBatch = []
+    this.debounceInterval = 5
+
+    this.processMutation = this.processMutation.bind(this)
+  }
+
+  public start(node: Node, config: MutationObserverInit) {
+    this.observer = new MutationObserver(this.processMutation)
+    this.observer.observe(node, config)
+  }
+
+  private debounceProcessedNodes() {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+    }
+
+    this.debounceTimer = window.setTimeout(() => {
+      this.processedNodes.clear()
+    }, this.debounceInterval * 10)
+  }
+
+  private debounceProcessBatch() {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+    }
+
+    this.debounceTimer = window.setTimeout(() => {
+      this.processBatch()
+    }, this.debounceInterval) // Adjust the delay as needed
+  }
+
+  private processBatch() {
+    if (this.messagesBatch.length === 0) {
+      return
+    }
+
+    //console.log(`Processing batch of ${this.messagesBatch.length} messages`)
+    this.messagesBatch.forEach((message) => this.queue.addMessage(message))
+    this.messagesBatch = []
+  }
+
+  private processMutation(mutations: MutationRecord[]) {
+    // Check if the first mutation's previous sibling is a span element
+    // @ts-ignore
+    if (mutations[0].previousSibling?.localName === "span") {
+      return
+    }
+
+    for (let mutation of mutations) {
+      if (mutation.type !== "childList") {
+        //console.log("Not a childList mutation")
+        continue
+      }
+
+      mutation.addedNodes.forEach((addedNode) => {
+        if (!(addedNode instanceof HTMLElement)) {
+          return
+        }
+
+        if (this.processedNodes.has(addedNode)) {
+          return // Skip already processed nodes
+        }
+
+        if (addedNode.classList.contains("chat-line__message")) {
+          this.messagesBatch.push(addedNode)
+          this.processedNodes.add(addedNode)
+        }
+      })
+    }
+
+    this.debounceProcessBatch()
+  }
+}
+
+export { ChatMutationObserver }

--- a/extension/src/scripting/queue.ts
+++ b/extension/src/scripting/queue.ts
@@ -1,0 +1,77 @@
+import {enhanceChatMessage} from "~scripting/components";
+
+class MessageQueue {
+  messages: any[] = []
+  processing: boolean = false
+
+  constructor() {
+    this.messages = []
+    this.processing = false
+  }
+
+  addMessage(message: any) {
+    this.messages.push(message)
+
+    if (!this.isProcessing()) {
+      this.processNext()
+    }
+  }
+
+  processNextMessage() {
+    if (this.isEmpty()) {
+      return "Queue is empty"
+    }
+    return this.messages.shift()
+  }
+
+  isProcessing() {
+    return this.processing
+  }
+
+  async processNext() {
+    if (this.isProcessing()) {
+      console.log("TBC: Already processing, waiting...")
+      return
+    }
+    if (this.isEmpty()) {
+      console.log("TBC: Queue is empty")
+      this.processing = false
+      return
+    }
+
+    this.processing = true
+    const item = this.processNextMessage()
+    console.log("TBC: Processing next item")
+    console.log(item)
+
+    // Simulate async processing
+    try {
+      // Simulate async processing
+      await this.processItem(item);
+    } catch (error) {
+      console.error("Error processing item:", error);
+    } finally {
+      this.processing = false;
+      await this.processNext();
+    }
+  }
+
+  async processItem(item: HTMLElement) {
+    return new Promise((resolve, reject) => {
+      try {
+        //console.log(`Processing item: ${item}`);
+        enhanceChatMessage(item);
+        resolve(true);
+      } catch (error) {
+        reject(error);
+      }
+    })
+  }
+
+  private isEmpty() {
+    return this.messages.length === 0
+  }
+}
+
+
+export { MessageQueue }


### PR DESCRIPTION
## Motivation

On the previous version I was noticing that there was some messages which basically doesn't loaded properly after two or more people sends in the same "timing".

After some investigation, found the problem which is basically: one node can be processed "twice" if the observer gets a new element. Something like this:

* New element added (1)
* Processing Elements (1)
* Element Processed (_)
* New Element Added (1)
* Processing Elements (1)
* New element Added (1,2)
* Processing Elements (1,2)
* Element Processed (2)
* Processing Elements (2)
* Element Processed (_)

### Changes

- [x] Added MessageQueue  to process messages (src/scripting/queue.ts)
- [x] Added ChatMutationObserver with debouncing options (src/scripting/observer.ts)
- [x] Enhanced the `content.ts` base structure
