### PR TITLE
feat: adding page watcher

### DIFF
--- a/extension/.idea/inspectionProfiles/Project_Default.xml
+++ b/extension/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="XmlDeprecatedElement" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,6 +1,6 @@
 import type { PlasmoCSConfig } from "plasmo";
 
-import { appLoader } from "~scripting";
+import Kernel from "@Scripting/index";
 
 export const config: PlasmoCSConfig = {
   matches: [
@@ -19,4 +19,4 @@ export const config: PlasmoCSConfig = {
 
 // @ts-ignore
 
-appLoader();
+new Kernel().init();

--- a/extension/src/scripting/components.ts
+++ b/extension/src/scripting/components.ts
@@ -3,7 +3,6 @@ import { t } from "~utils/i18nUtils";
 const API_URL: string = process.env.PLASMO_PUBLIC_API_URL;
 
 const enhanceChatMessage = async (messageEl: HTMLElement) => {
-  console.log(messageEl.textContent);
   const usernameEl = messageEl.querySelector(".chat-line__username");
   let badgesEl = messageEl.querySelector(".chat-line__username-container");
 
@@ -25,7 +24,6 @@ const enhanceChatMessage = async (messageEl: HTMLElement) => {
   }
 
   const res = await req.json();
-
   const child = usernameEl.firstChild;
 
   const pronouns = res.pronouns.replace("/", "");

--- a/extension/src/scripting/observer.ts
+++ b/extension/src/scripting/observer.ts
@@ -1,6 +1,6 @@
-import { MessageQueue } from "~scripting/queue";
+import MessageQueue from "~scripting/queue";
 
-class ChatMutationObserver {
+export default class ChatMutationObserver {
   private observer: MutationObserver;
 
   private queue: MessageQueue;
@@ -21,6 +21,10 @@ class ChatMutationObserver {
   public start(node: Node, config: MutationObserverInit) {
     this.observer = new MutationObserver(this.processMutation);
     this.observer.observe(node, config);
+  }
+
+  public stop() {
+    this.observer.disconnect();
   }
 
   /** Stops  */
@@ -89,5 +93,3 @@ class ChatMutationObserver {
     this.debounceProcessBatch();
   }
 }
-
-export { ChatMutationObserver };

--- a/extension/src/scripting/queue.ts
+++ b/extension/src/scripting/queue.ts
@@ -1,6 +1,6 @@
-import { enhanceChatMessage } from "~scripting/components";
+import { enhanceChatMessage } from "@Scripting/components";
 
-class MessageQueue {
+export default class MessageQueue {
   messages: HTMLElement[] = [];
   processing = false;
 
@@ -10,7 +10,6 @@ class MessageQueue {
   }
 
   addMessage(message: HTMLElement) {
-    console.log(message);
     this.messages.push(message);
 
     if (!this.isProcessing()) {
@@ -30,19 +29,18 @@ class MessageQueue {
 
   async processNext() {
     if (this.isProcessing()) {
-      console.log("TBC: Already processing, waiting...");
+      console.log("TBP: Already processing, waiting...");
       return;
     }
     if (this.isEmpty()) {
-      console.log("TBC: Queue is empty");
+      console.log("TBP: Queue is empty");
       this.processing = false;
       return;
     }
 
     this.processing = true;
     const item = this.processNextMessage();
-    console.log("TBC: Processing next item");
-    console.log(item);
+    console.log("TBP: Processing next message...");
 
     // Simulate async processing
     try {
@@ -75,4 +73,3 @@ class MessageQueue {
   }
 }
 
-export { MessageQueue };

--- a/extension/src/scripting/watchers/page-watcher.ts
+++ b/extension/src/scripting/watchers/page-watcher.ts
@@ -1,0 +1,59 @@
+const watchablePages = [
+  /^https:\/\/dashboard\.twitch\.tv\/u\/[^\/]+\/stream-manager$/,
+  /^https:\/\/www\.twitch\.tv\/embed\/[^\/]+\/chat.*$/,
+  /^https:\/\/www\.twitch\.tv\/[^\/]+$/,
+];
+
+export enum PageWatcherState {
+  MATCHED,
+  REFRESHED,
+  STANDBY,
+}
+
+export default class PageWatcher {
+  private currentPath: string;
+  public pageState: PageWatcherState;
+  public observerRunning: boolean;
+
+  init() {
+    console.log("TBP: PageWatcher initialized");
+    this.pageState = PageWatcherState.STANDBY;
+    this.observerRunning = false;
+    setInterval(() => this.trackPathChanges(), 50);
+  }
+
+  public matches() {
+    return this.pageState === PageWatcherState.MATCHED;
+  }
+
+  public refresh() {
+    return this.pageState === PageWatcherState.REFRESHED;
+  }
+
+  private trackPathChanges() {
+    if (this.currentPath === window.location.href) {
+      return;
+    }
+    console.log("TBP: Path changed");
+    this.currentPath = window.location.href;
+
+    const isWatchableUrl = watchablePages.some((pattern) =>
+      pattern.test(this.currentPath),
+    );
+
+    if (!isWatchableUrl) {
+      console.log("TBP: Ignoring page change");
+      this.pageState = PageWatcherState.STANDBY;
+      return;
+    }
+
+    if (this.pageState === PageWatcherState.MATCHED) {
+      this.pageState = PageWatcherState.REFRESHED;
+      console.log("TBP: Detected page refresh");
+      return;
+    }
+
+    this.pageState = PageWatcherState.MATCHED;
+    console.log("TBP: Detected page change");
+  }
+}

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -9,7 +9,8 @@
       "@Shad/*": ["./src/resources/shad/*"],
       "@Components/*": ["./src/resources/components/*"],
       "@Pages/*": ["./src/resources/pages/*"],
-      "@Config/*": ["./src/config/*"]
+      "@Config/*": ["./src/config/*"],
+      "@Scripting/*": ["./src/scripting/*"],
     },
     "baseUrl": "."
   }


### PR DESCRIPTION
## Motivation 

One of our goals is to provide a smooth integration with Twitch as a whole, but until now we only supported the actual refreshed browser tab and if you switch to another inside Twitch, the app stops working.

### Changes

- [x] Added base Kernel for upcoming watchers/observers
- [x] Added Page Watcher to validate if you need to restart the current observer.

Closes #21 