### PR TITLE
feat(header): add extension version on header

### DIFF
--- a/extension/src/resources/components/app/header.tsx
+++ b/extension/src/resources/components/app/header.tsx
@@ -1,15 +1,17 @@
 import { ModeToggle } from "@Components/app/mode-toggle";
 import { H4 } from "@Shad/components/ui/typography/h4";
 import { User as UserIcon } from "lucide-react";
+import { version } from "@Root/package.json"
 
 import { t } from "~utils/i18nUtils";
 
 export default function Header() {
   return (
     <div className="flex my-2 flex-row justify-between px-3 items-center">
-      <div className="flex gap-2 dark:text-twitch-11">
+      <div className="flex gap-2 dark:text-twitch-11 items-center">
         <UserIcon />
         <H4>{t("headerTitle")}</H4>
+        <span className=" font-light tracking-tight text-xs mt-1 text-slate-100">v{version}</span>
       </div>
       <ModeToggle />
     </div>

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -11,6 +11,7 @@
       "@Pages/*": ["./src/resources/pages/*"],
       "@Config/*": ["./src/config/*"],
       "@Scripting/*": ["./src/scripting/*"],
+      "@Root/*": ["./*"],
     },
     "baseUrl": "."
   }


### PR DESCRIPTION
## Solution
I'm getting the version from the `package.json`. Also, I created a new alias to make it easer to get root files.

- resolves: #16 

## Preview

![image](https://github.com/user-attachments/assets/bccc5e0d-9d7a-4bcc-bdd6-4c28fcc46f4e)
![image](https://github.com/user-attachments/assets/af1c380b-7952-42c7-9721-93d619eb30de)
