### PR TITLE
Adjust logout button hierarchy to comply with design principles

### DIFF
--- a/extension/src/resources/components/app/header.tsx
+++ b/extension/src/resources/components/app/header.tsx
@@ -5,7 +5,7 @@ import { Button } from "~resources/shad/components/ui/button";
 
 import { t } from "~utils/i18nUtils";
 type HeaderProps = {
-  onStorageClear: () => void;
+  onStorageClear?: () => void;
 };
 export default function Header({ onStorageClear }: HeaderProps) {
   return (
@@ -14,14 +14,17 @@ export default function Header({ onStorageClear }: HeaderProps) {
         <UserIcon />
         <H4>{t("headerTitle")}</H4>
       </div>
+
       <div className="flex gap-2">
-        <Button
-          onClick={onStorageClear}
-          size="icon"
-          className="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 w-10"
-        >
-          <LogOut size={20} />
-        </Button>
+        {onStorageClear ? (
+          <Button
+            onClick={onStorageClear}
+            size="icon"
+            className="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground"
+          >
+            <LogOut size={20} />
+          </Button>
+        ) : null}
         <ModeToggle />
       </div>
     </div>

--- a/extension/src/resources/components/app/header.tsx
+++ b/extension/src/resources/components/app/header.tsx
@@ -1,17 +1,29 @@
 import { ModeToggle } from "@Components/app/mode-toggle";
 import { H4 } from "@Shad/components/ui/typography/h4";
-import { User as UserIcon } from "lucide-react";
+import { LogOut, User as UserIcon } from "lucide-react";
+import { Button } from "~resources/shad/components/ui/button";
 
 import { t } from "~utils/i18nUtils";
-
-export default function Header() {
+type HeaderProps = {
+  onStorageClear: () => void;
+};
+export default function Header({ onStorageClear }: HeaderProps) {
   return (
     <div className="flex my-2 flex-row justify-between px-3 items-center">
       <div className="flex gap-2 dark:text-twitch-11">
         <UserIcon />
         <H4>{t("headerTitle")}</H4>
       </div>
-      <ModeToggle />
+      <div className="flex gap-2">
+        <Button
+          onClick={onStorageClear}
+          size="icon"
+          className="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 w-10"
+        >
+          <LogOut size={20} />
+        </Button>
+        <ModeToggle />
+      </div>
     </div>
   );
 }

--- a/extension/src/resources/components/auth/authenticate-button.tsx
+++ b/extension/src/resources/components/auth/authenticate-button.tsx
@@ -7,7 +7,6 @@ import { t } from "~utils/i18nUtils";
 
 export default function AuthenticateButton() {
   const authenticate = async () => {
-    console.log("authenticate");
     await sendToBackground({
       name: "oauth",
     });

--- a/extension/src/resources/components/settings/settings-form.tsx
+++ b/extension/src/resources/components/settings/settings-form.tsx
@@ -34,7 +34,6 @@ export default function SettingsForm({
 
   const updateSettings = async () => {
     const storage = new Storage();
-    console.log("Updating pronouns");
     const selectedPronoun = pronounsListEl.current.value;
     const selectedOccupation = occupationListEl.current.value;
     const response = await fetch(

--- a/extension/src/resources/pages/profile.tsx
+++ b/extension/src/resources/pages/profile.tsx
@@ -14,13 +14,13 @@ type ProfileProps = {
 };
 
 export default function Profile({ user }: ProfileProps) {
-  const storage = new Storage();
+  const onStorageClear = new Storage().clear;
   const [currentPronouns] = useStorage("pronouns");
   const [currentOccupation] = useStorage("occupation");
 
   return (
     <div className="max-w-96">
-      <Header />
+      <Header onStorageClear={onStorageClear} />
       <div>
         <ProfileCard
           user={user}
@@ -35,14 +35,6 @@ export default function Profile({ user }: ProfileProps) {
           occupation={currentOccupation}
         />
       </div>
-      <Button
-        className={"w-full"}
-        onClick={() => {
-          storage.clear();
-        }}
-      >
-        {t("logoutButtonText")}
-      </Button>
     </div>
   );
 }

--- a/extension/src/resources/pages/profile.tsx
+++ b/extension/src/resources/pages/profile.tsx
@@ -7,7 +7,6 @@ import { Storage } from "@plasmohq/storage";
 import { useStorage } from "@plasmohq/storage/dist/hook";
 
 import type { TwitchUser } from "~types/types";
-import { t } from "~utils/i18nUtils";
 
 type ProfileProps = {
   user: TwitchUser;


### PR DESCRIPTION
### Summary

I opened this issue about the logout button. Which at the bottom of the app like an CTA, breaks the fundamental UI/UX design principles. read more here: [UX Design Principles](https://app.uxcel.com/courses/design-foundations/ux-design-principles-284#:~:text=Even%20small%20issues,can%20hurt%20usability.)

### What I did:

- removed button from the bottom
- added a void function as prop to the header component
- added a conditional rendering to only shows the logout icon when the props is set(user is logged)
- removed leftover console.log statements

### After vs Before


| after | before |
|--------|--------|
| ![Screenshot 2024-08-08 at 21 27 23](https://github.com/user-attachments/assets/d053bb10-0576-478e-81c5-7e5cd631d57d)| ![Screenshot 2024-08-08 at 22 04 40](https://github.com/user-attachments/assets/926df790-9ce3-4b44-bdac-3a0b3129a99a)| 

