### PR TITLE
fix: 7tv compatibility

### DIFF
--- a/extension/src/resources/components/app/header.tsx
+++ b/extension/src/resources/components/app/header.tsx
@@ -4,9 +4,9 @@ import { H4 } from "@Shad/components/ui/typography/h4";
 import { LogOut, User as UserIcon } from "lucide-react";
 import { Button } from "~resources/shad/components/ui/button";
 
-import { t } from "~utils/i18nUtils";
 import { Storage } from "@plasmohq/storage";
 import { useStorage } from "@plasmohq/storage/dist/hook";
+import { t } from "~utils/i18nUtils";
 
 export default function Header() {
   const [isAuthenticated] = useStorage("accessToken");

--- a/extension/src/resources/components/settings/chat-appearance.tsx
+++ b/extension/src/resources/components/settings/chat-appearance.tsx
@@ -2,8 +2,8 @@ import Logo from "data-base64:@Root/assets/icon.png";
 import { cn } from "@Shad/lib/utils";
 import type { TwitchUser } from "~types/types";
 
-import { t } from "~utils/i18nUtils";
 import { env } from "@Config/env";
+import { t } from "~utils/i18nUtils";
 
 type ChatAppearanceProps = {
   user: TwitchUser;

--- a/extension/src/resources/pages/profile.tsx
+++ b/extension/src/resources/pages/profile.tsx
@@ -3,20 +3,19 @@ import ProfileCard from "@Components/settings/profile-card";
 import SettingsForm from "@Components/settings/settings-form";
 import { Button } from "@Shad/components/ui/button";
 
-import { useStorage } from "@plasmohq/storage/dist/hook";
 import AboutCard from "@Components/about/about";
 import ChatAppearance from "@Components/settings/chat-appearance";
 import Tabs from "@Shad/components/ui/tabs";
+import { useStorage } from "@plasmohq/storage/dist/hook";
 
 import type { TwitchUser } from "~types/types";
-import {t} from "~utils/i18nUtils";
+import { t } from "~utils/i18nUtils";
 
 type ProfileProps = {
   user: TwitchUser;
 };
 
 export default function Profile({ user }: ProfileProps) {
-
   const [currentPronouns] = useStorage("pronouns");
   const [currentOccupation] = useStorage("occupation");
   const [color] = useStorage("color");

--- a/extension/src/resources/shad/components/ui/tabs.tsx
+++ b/extension/src/resources/shad/components/ui/tabs.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import * as Tab from "@radix-ui/react-tabs";
+import type React from "react";
 
 type Tab = {
   name: string;

--- a/extension/src/resources/shad/components/ui/tabs.tsx
+++ b/extension/src/resources/shad/components/ui/tabs.tsx
@@ -1,14 +1,14 @@
 import * as Tab from "@radix-ui/react-tabs";
 import type React from "react";
 
-type Tab = {
+type Tabs = {
   name: string;
   value: string;
   content: React.ReactNode;
 };
 
 type TabsProps = {
-  tabData: Tab[];
+  tabData: Tabs[];
 };
 
 const TabTrigger: React.FC<{ name: string; value: string }> = ({

--- a/extension/src/scripting/components.ts
+++ b/extension/src/scripting/components.ts
@@ -2,14 +2,28 @@ import { t } from "~utils/i18nUtils";
 
 const API_URL: string = process.env.PLASMO_PUBLIC_API_URL;
 
-const enhanceChatMessage = async (messageEl: HTMLElement) => {
-  const usernameEl = messageEl.querySelector(".chat-line__username");
-  let badgesEl = messageEl.querySelector(".chat-line__username-container");
+const TWITCH_BADGES_CONTAINER = ".chat-line__username-container";
+const SEVEN_TV_BADGES_CONTAINER = ".seventv-chat-user-badge-list";
 
-  if (!badgesEl) {
-    return;
+const TWITCH_USERNAME_CONTAINER = ".chat-line__username";
+const SEVEN_TV_USERNAME_CONTAINER = ".seventv-chat-user-username";
+const USERNAME_CONTAINER = `${TWITCH_USERNAME_CONTAINER},${SEVEN_TV_USERNAME_CONTAINER}`;
+
+const enhanceChatMessage = async (messageEl: HTMLElement) => {
+
+  const usernameEl = messageEl.querySelector(USERNAME_CONTAINER);
+
+  /**
+   * TODO: make adapters based on which plugins the user has installed (compatibility mode)
+   * Restructure the code to make it more modular and easy to maintain (Goal: 1.0.0)
+   **/
+  let badgesEl: Element;
+  badgesEl = messageEl.querySelector(TWITCH_BADGES_CONTAINER);
+  if (badgesEl) {
+    badgesEl = badgesEl.childNodes[0] as Element;
+  } else {
+    badgesEl = messageEl.querySelector(SEVEN_TV_BADGES_CONTAINER);
   }
-  badgesEl = badgesEl.childNodes[0] as Element;
 
   if (!usernameEl) {
     return;
@@ -42,7 +56,9 @@ const enhanceChatMessage = async (messageEl: HTMLElement) => {
 const buildBadge = (occupation) => {
   // Create a div element
   const badgeContainer = document.createElement("div");
-  badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA";
+  badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA seventv-chat-badge";
+  // SevenTV Stuff
+  badgeContainer.setAttributeNode(document.createAttribute("data-v-9f956e7d"));
 
   // Create an img element
   const img = document.createElement("img");

--- a/extension/src/scripting/components.ts
+++ b/extension/src/scripting/components.ts
@@ -10,7 +10,6 @@ const SEVEN_TV_USERNAME_CONTAINER = ".seventv-chat-user-username";
 const USERNAME_CONTAINER = `${TWITCH_USERNAME_CONTAINER},${SEVEN_TV_USERNAME_CONTAINER}`;
 
 const enhanceChatMessage = async (messageEl: HTMLElement) => {
-
   const usernameEl = messageEl.querySelector(USERNAME_CONTAINER);
 
   /**
@@ -56,7 +55,8 @@ const enhanceChatMessage = async (messageEl: HTMLElement) => {
 const buildBadge = (occupation) => {
   // Create a div element
   const badgeContainer = document.createElement("div");
-  badgeContainer.className = "InjectLayout-sc-1i43xsx-0 jbmPmA seventv-chat-badge";
+  badgeContainer.className =
+    "InjectLayout-sc-1i43xsx-0 jbmPmA seventv-chat-badge";
   // SevenTV Stuff
   badgeContainer.setAttributeNode(document.createAttribute("data-v-9f956e7d"));
 

--- a/extension/src/scripting/index.ts
+++ b/extension/src/scripting/index.ts
@@ -3,7 +3,9 @@ import PageWatcher, {
   PageWatcherState,
 } from "@Scripting/watchers/page-watcher";
 
-const CHAT_LIST = ".chat-list--default,.chat-list--other,.chat-list";
+const TWITCH_CHAT_LIST = ".chat-list--default,.chat-list--other,.chat-list";
+const SEVEN_TV_CHAT_LIST = ".seventv-chat-list";
+const CHAT_LIST = `${TWITCH_CHAT_LIST},${SEVEN_TV_CHAT_LIST}`;
 
 export default class Kernel {
   // Core components

--- a/extension/src/scripting/observer.ts
+++ b/extension/src/scripting/observer.ts
@@ -95,7 +95,6 @@ export default class ChatMutationObserver {
             this.processedNodes.add(addedNode);
           }
         }
-
       });
     }
 

--- a/extension/src/scripting/observer.ts
+++ b/extension/src/scripting/observer.ts
@@ -1,5 +1,9 @@
 import MessageQueue from "~scripting/queue";
 
+const TWITCH_CHAT_CONTAINER = "chat-line__message";
+const SEVEN_TV_CHAT_CONTAINER = "seventv-message";
+const CHAT_CONTAINER = [TWITCH_CHAT_CONTAINER, SEVEN_TV_CHAT_CONTAINER];
+
 export default class ChatMutationObserver {
   private observer: MutationObserver;
 
@@ -66,6 +70,7 @@ export default class ChatMutationObserver {
     if (mutations[0].previousSibling?.localName === "span") {
       return;
     }
+    console.log("TBP: Mutation detected");
 
     for (const mutation of mutations) {
       if (mutation.type !== "childList") {
@@ -82,11 +87,15 @@ export default class ChatMutationObserver {
         if (this.processedNodes.has(addedNode)) {
           return; // Skip already processed nodes
         }
-
-        if (addedNode.classList.contains("chat-line__message")) {
-          this.messagesBatch.push(addedNode);
-          this.processedNodes.add(addedNode);
+        console.log("TBP: ", addedNode.classList);
+        for (const container of CHAT_CONTAINER) {
+          if (addedNode.classList.contains(container)) {
+            console.log("TBP: Added node detected");
+            this.messagesBatch.push(addedNode);
+            this.processedNodes.add(addedNode);
+          }
         }
+
       });
     }
 


### PR DESCRIPTION
## Motivation

7TV is adopted among most of the streamers/viewers and we should take this in consideration. After the discussion at #25 we saw that the most realistic possibility was to validate if the person uses the plugin on the fly. 

![image](https://github.com/user-attachments/assets/91814717-6cfe-4765-81b4-8737480a6c35)

In the 1.0.0 we need to break down the problem and decide if we: 
- ask for permission to check their plugins and ask for disable (like 7tv)
- create adapters for everything
- force disable and create a new chat div

### Changes

- [x] Added poor "adapter" to 7tv plugin
- [x] Fixed errors from `pnpm check:fix`

Closes #25 